### PR TITLE
statistics - allow rrd files to contain :

### DIFF
--- a/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
+++ b/applications/luci-app-statistics/luasrc/statistics/rrdtool.lua
@@ -62,7 +62,7 @@ function Graph._mkpath( self, plugin, plugin_instance, dtype, dtype_instance )
 end
 
 function Graph.mkrrdpath( self, ... )
-	return string.format( "%s/%s.rrd", self.opts.rrdpath, self:_mkpath( ... ) )
+	return string.format( "%s/%s.rrd", self.opts.rrdpath, string.gsub(self:_mkpath( ... ), ":", "\\:") )
 end
 
 function Graph.mkpngpath( self, ... )


### PR DESCRIPTION
Fixes situations where RRD file name contains ":" (eg. _ping/ipv6_) in `rrdtool` it's unescaped - thus not able to render image. Adding simple escaping of `:` to `\\:`.

Might be a solution for #958.